### PR TITLE
Actually return true/false from `validar` function

### DIFF
--- a/lib/__tests__/curp.test.js
+++ b/lib/__tests__/curp.test.js
@@ -281,11 +281,11 @@ describe('curp', () => {
   });
 
   it('Deberia obtener false al validar un curp incorrecto', () => {
-    expect(curp.validar('XARA750909HDFNDL01')).toBeFalsy();
+    expect(curp.validar('XARA750909HDFNDL01')).toBe(false);
   });
 
   it('Deberia obtener true al validar un curp correcto', () => {
-    expect(curp.validar('PXNE660720HMCXTN06')).toBeTruthy();
-    expect(curp.validar('LOOA531113HTCPBN07')).toBeTruthy();
+    expect(curp.validar('PXNE660720HMCXTN06')).toBe(true);
+    expect(curp.validar('LOOA531113HTCPBN07')).toBe(true);
   });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -493,11 +493,10 @@ function validar(curpToValidate) {
   const regex =
     /^([A-Z][AEIOUX][A-Z]{2}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])[HM](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d])(\d)$/;
   const validado = curpToValidate.match(regex);
-  if (
+  return (
     validado &&
     parseInt(validado[2], 10) === agregaDigitoVerificador(validado[1])
-  )
-    return true;
+  );
 }
 
 curp.validar = validar;


### PR DESCRIPTION
The `validar` function returns `true/undefined` when the documentation says that it returns `true/false`, some changes in the tests to verify this and a minor change in code to be compliant with the documentation, and in my opinion, the firm of the function.