### PR TITLE
Bugfix/problema con nombre comunes

### DIFF
--- a/lib/__tests__/curp.test.js
+++ b/lib/__tests__/curp.test.js
@@ -154,6 +154,28 @@ describe('curp', () => {
     persona.estado = curp.ESTADO.SAN_LUIS_POTOSI;
     expect(curp.generar(persona)).toBe('MARR810908MSPRVS00');
   });
+  
+  it('Deberia obtener el CURP correcto de ONDREJ JUAN HERNANDEZ LOPEZ tomando como nombre ONDREJ y no JUAN', () => {
+    const persona = curp.getPersona();
+    persona.nombre = 'ONDREJ JUAN';
+    persona.apellidoPaterno = 'HERNANDEZ';
+    persona.apellidoMaterno = 'LOPEZ';
+    persona.genero = curp.GENERO.MASCULINO;
+    persona.fechaNacimiento = '01-05-1999';
+    persona.estado = curp.ESTADO.VERACRUZ;
+    expect(curp.generar(persona)).toBe('HELO990501HVZRPN09');
+  });
+  
+  it('Deberia obtener el CURP correcto de IRMA LETICIA MAR SOLIS tomando como nombre IRMA y no LETICIA', () => {
+    const persona = curp.getPersona();
+    persona.nombre = 'IRMA LETICIA';
+    persona.apellidoPaterno = 'MAR';
+    persona.apellidoMaterno = 'SOLIS';
+    persona.genero = curp.GENERO.FEMENINO;
+    persona.fechaNacimiento = '05-08-2005';
+    persona.estado = curp.ESTADO.VERACRUZ;
+    expect(curp.generar(persona)).toBe('MASI050805MVZRLRA8');
+  });
 
   it('Deberia obtener el CURP correcto de JOSE SAUL GALVAN DEL RIO', () => {
     const persona = curp.getPersona();

--- a/lib/index.js
+++ b/lib/index.js
@@ -453,7 +453,7 @@ function getSpecialChar(bornYear) {
 function obtenerNombreUsar(nombre) {
   const nombres = nombre.trim().split(/\s+/);
   const esNombreComun = comunes.some((nombreComun) =>
-    nombre.includes(nombreComun)
+    nombre.indexOf(nombreComun) === 0
   );
   if (esNombreComun) {
     nombres.reverse();


### PR DESCRIPTION
Cuando es un nombre compuesto de 2 o más palabras la funcion `obtenerNombreUsar()` debe retornar el nombre a usar validándolo con las palabras del array "comunes", por ejemplo "MA ANGELES" retronará "ANGELES"  **(eso es correcto)** sin embargo para el nombre "IRMA LETICIA" retorna "LETICIA" **(eso es incorrecto)** ya que la función `includes()` en la función `obtenerNombreUsar()` valida si el nombre común está contenido en el nombre dado sin importar la posición, para solucionar este error se cambió la función de callback  `includes()` a  `indexOf()` y a su vez validar que el retorno sea igual a `0` ya que el nombre común tiene que estar en el primer nombre, como lo dice la disposición oficial:

![nombres-comunes](https://user-images.githubusercontent.com/51386097/193691322-67712ff8-d6ce-4e3e-984c-668cd10611eb.png)

Saludos...
