### PR TITLE
Bugfix/nombres comunes con mas de dos nombres

### DIFF
--- a/lib/__tests__/curp.test.js
+++ b/lib/__tests__/curp.test.js
@@ -154,7 +154,7 @@ describe('curp', () => {
     persona.estado = curp.ESTADO.SAN_LUIS_POTOSI;
     expect(curp.generar(persona)).toBe('MARR810908MSPRVS00');
   });
-  
+
   it('Deberia obtener el CURP correcto de ONDREJ JUAN HERNANDEZ LOPEZ tomando como nombre ONDREJ y no JUAN', () => {
     const persona = curp.getPersona();
     persona.nombre = 'ONDREJ JUAN';
@@ -165,7 +165,7 @@ describe('curp', () => {
     persona.estado = curp.ESTADO.VERACRUZ;
     expect(curp.generar(persona)).toBe('HELO990501HVZRPN09');
   });
-  
+
   it('Deberia obtener el CURP correcto de IRMA LETICIA MAR SOLIS tomando como nombre IRMA y no LETICIA', () => {
     const persona = curp.getPersona();
     persona.nombre = 'IRMA LETICIA';

--- a/lib/__tests__/curp.test.js
+++ b/lib/__tests__/curp.test.js
@@ -177,6 +177,39 @@ describe('curp', () => {
     expect(curp.generar(persona)).toBe('MASI050805MVZRLRA8');
   });
 
+  it('Deberia obtener el CURP correcto de MARIA ERNESTINA RAFAELA CONTRERAS MORALES tomando como nombre ERNESTINA y no RAFAELA', () => {
+    const persona = curp.getPersona();
+    persona.nombre = 'MARIA ERNESTINA RAFAELA';
+    persona.apellidoPaterno = 'CONTRERAS';
+    persona.apellidoMaterno = 'MORALES';
+    persona.genero = curp.GENERO.FEMENINO;
+    persona.fechaNacimiento = '10-11-1972';
+    persona.estado = curp.ESTADO.VERACRUZ;
+    expect(curp.generar(persona)).toBe('COME721110MVZNRR03');
+  });
+
+  it('Deberia obtener el CURP correcto de MARIA VILLA TRUJILLO', () => {
+    const persona = curp.getPersona();
+    persona.nombre = 'MARIA';
+    persona.apellidoPaterno = 'VILLA';
+    persona.apellidoMaterno = 'TRUJILLO';
+    persona.genero = curp.GENERO.FEMENINO;
+    persona.fechaNacimiento = '06-09-1982';
+    persona.estado = curp.ESTADO.VERACRUZ;
+    expect(curp.generar(persona)).toBe('VITM820906MVZLRR00');
+  });
+
+  it('Deberia obtener el CURP correcto de JOSE MARIA TEZOCO APALE', () => {
+    const persona = curp.getPersona();
+    persona.nombre = 'JOSE MARIA';
+    persona.apellidoPaterno = 'TEZOCO';
+    persona.apellidoMaterno = 'APALE';
+    persona.genero = curp.GENERO.MASCULINO;
+    persona.fechaNacimiento = '22-06-1947';
+    persona.estado = curp.ESTADO.VERACRUZ;
+    expect(curp.generar(persona)).toBe('TEAM470622HVZZPR07');
+  });
+
   it('Deberia obtener el CURP correcto de JOSE SAUL GALVAN DEL RIO', () => {
     const persona = curp.getPersona();
     persona.nombre = 'JOSE SAUL';

--- a/lib/index.js
+++ b/lib/index.js
@@ -141,6 +141,8 @@ const malasPalabras = {
   WUEY: 'WXEY',
 };
 
+/* eslint max-params: ["error", 6] */
+/* eslint-env es6 */
 class Persona {
   constructor(
     nombre,
@@ -452,8 +454,8 @@ function getSpecialChar(bornYear) {
  */
 function obtenerNombreUsar(nombre) {
   const nombres = nombre.trim().split(/\s+/);
-  const esNombreComun = comunes.some((nombreComun) =>
-    nombre.indexOf(nombreComun) === 0
+  const esNombreComun = comunes.some(
+    (nombreComun) => nombre.indexOf(nombreComun) === 0
   );
   if (esNombreComun) {
     nombres.reverse();

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,19 @@ const ESTADO = {
   ZACATECAS: 'ZS',
 };
 
+const comunes = [
+  'MARIA DEL ',
+  'MARIA DE LOS ',
+  'MARIA ',
+  'JOSE DE ',
+  'JOSE ',
+  'MA. ',
+  'MA ',
+  'M. ',
+  'J. ',
+  'J ',
+];
+
 const malasPalabras = {
   BACA: 'BXCA',
   BAKA: 'BXKA',
@@ -446,12 +459,11 @@ function obtenerNombreUsar(nombre) {
   const nombres = nombre.trim().split(/\s+/);
   if (nombres.length === 1) return nombres[0];
 
-  const comunes = ['MARIA ', 'MA. ', 'MA ', 'M. ', 'M ', 'JOSE ', 'J. ', 'J '];
   const esNombreComun = comunes.some(
     (nombreComun) => nombre.indexOf(nombreComun) === 0
   );
-  if (esNombreComun) nombres[0] = nombres[1];
 
+  if (esNombreComun) return nombres[1];
   return nombres[0];
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,19 +44,6 @@ const ESTADO = {
   ZACATECAS: 'ZS',
 };
 
-const comunes = [
-  'MARIA DEL ',
-  'MARIA DE LOS ',
-  'MARIA ',
-  'JOSE DE ',
-  'JOSE ',
-  'MA. ',
-  'MA ',
-  'M. ',
-  'J. ',
-  'J ',
-];
-
 const malasPalabras = {
   BACA: 'BXCA',
   BAKA: 'BXKA',
@@ -169,8 +156,10 @@ function generar(persona) {
   validaDatos(persona);
   let curp = '';
   const pad = zeropad.bind(null, 2);
-  const nombre = normalizaString(persona.nombre.toUpperCase()).trim();
-  const nombreUsar = obtenerNombreUsar(nombre);
+
+  const nombre = ajustaCompuesto(
+    normalizaString(persona.nombre.toUpperCase())
+  ).trim();
 
   const apellidoPaterno = ajustaCompuesto(
     normalizaString(persona.apellidoPaterno.toUpperCase())
@@ -181,6 +170,7 @@ function generar(persona) {
     normalizaString(apellidoMaterno.toUpperCase())
   ).trim();
 
+  const nombreUsar = obtenerNombreUsar(nombre);
   const inicialNombre = nombreUsar.substring(0, 1);
 
   let vocalApellido = apellidoPaterno
@@ -454,12 +444,13 @@ function getSpecialChar(bornYear) {
  */
 function obtenerNombreUsar(nombre) {
   const nombres = nombre.trim().split(/\s+/);
+  if (nombres.length === 1) return nombres[0];
+
+  const comunes = ['MARIA ', 'MA. ', 'MA ', 'M. ', 'M ', 'JOSE ', 'J. ', 'J '];
   const esNombreComun = comunes.some(
     (nombreComun) => nombre.indexOf(nombreComun) === 0
   );
-  if (esNombreComun) {
-    nombres.reverse();
-  }
+  if (esNombreComun) nombres[0] = nombres[1];
 
   return nombres[0];
 }


### PR DESCRIPTION
Se envía propuesta de solución al error de generación de CURP cuando la persona tiene más de dos nombres y su primer nombre sea un nombre común, ya que originalmente cuando se ingresaba un nombre como **MARIA ERNESTINA RAFAELA** la lógica de la función `obtenerNombreUsar()` retornaba **RAFAELA** en lugar de **ERNESTINA** debido a que utiliza la función `reverse()` al array nombres.

Para solucionar esto se cambió la lógica de validación en la función `obtenerNombreUsar()` ademas se hacer pasar a la variable `nombre` por `ajustaCompuesto()` y `normalizaString()` primero.

Espero sea de ayuda, saludos..
