### PR TITLE
Bugfix/apellidos abreviados con punto

### DIFF
--- a/lib/__tests__/curp.test.js
+++ b/lib/__tests__/curp.test.js
@@ -265,6 +265,28 @@ describe('curp', () => {
     expect(curp.generar(persona)).toBe('ZUNA540308MNELTN05');
   });
 
+  it('Deberia obtener el CURP correcto de la persona ANAHI N. LUIS MENDO', () => {
+    const persona = curp.getPersona();
+    persona.nombre = 'ANAHI';
+    persona.apellidoPaterno = 'N. LUIS';
+    persona.apellidoMaterno = 'MENDO';
+    persona.genero = curp.GENERO.FEMENINO;
+    persona.fechaNacimiento = '27-03-1981';
+    persona.estado = curp.ESTADO.VERACRUZ;
+    expect(curp.generar(persona)).toBe('NXMA810327MVZXNN08');
+  });
+
+  it('Deberia obtener el CURP correcto de la persona EDNA PEREZ H. TOLENTINO', () => {
+    const persona = curp.getPersona();
+    persona.nombre = 'EDNA';
+    persona.apellidoPaterno = 'PEREZ';
+    persona.apellidoMaterno = 'H. TOLENTINO';
+    persona.genero = curp.GENERO.FEMENINO;
+    persona.fechaNacimiento = '20-11-1977';
+    persona.estado = curp.ESTADO.VERACRUZ;
+    expect(curp.generar(persona)).toBe('PEHE771120MVZRXD09');
+  });
+
   function curpSinNombre() {
     const persona = curp.getPersona();
     persona.apellidoPaterno = 'Sanchez';

--- a/lib/index.js
+++ b/lib/index.js
@@ -229,7 +229,7 @@ function generar(persona) {
     pad(fechaNacimiento[0]),
     persona.genero,
     persona.estado,
-    posicionCatorceDieciseis,
+    filtraCaracteres(posicionCatorceDieciseis),
   ].join('');
 
   curp += getSpecialChar(fechaNacimiento[2]);


### PR DESCRIPTION
Al tratar de generar una CURP con apellidos abrevados con punto se generaba uno incorrecto.
Se envía sugerencia de solución y sus respectivas pruebas..