### PR TITLE
Bugfix/Error con espacio en posición dos del primer apellido

### DIFF
--- a/lib/__tests__/curp.test.js
+++ b/lib/__tests__/curp.test.js
@@ -265,6 +265,17 @@ describe('curp', () => {
     expect(curp.generar(persona)).toBe('ZUNA540308MNELTN05');
   });
 
+  it('Deberia obtener la CURP correcta de la persona ROSA GUADALUPE O RELLING ALVARADO', () => {
+    const persona = curp.getPersona();
+    persona.nombre = 'ROSA GUADALUPE';
+    persona.apellidoPaterno = 'O RELLING';
+    persona.apellidoMaterno = 'ALVARADO';
+    persona.genero = curp.GENERO.FEMENINO;
+    persona.fechaNacimiento = '22-01-1997';
+    persona.estado = curp.ESTADO.VERACRUZ;
+    expect(curp.generar(persona)).toBe('OXAR970122MVZXLS09');
+  });
+
   function curpSinNombre() {
     const persona = curp.getPersona();
     persona.apellidoPaterno = 'Sanchez';

--- a/lib/index.js
+++ b/lib/index.js
@@ -187,10 +187,10 @@ function generar(persona) {
   const inicialNombre = nombreUsar.substring(0, 1);
 
   let vocalApellido = apellidoPaterno
-    .trim()
     .substring(1)
     .replace(/[BCDFGHJKLMNÑPQRSTVWXYZ]/g, '')
-    .substring(0, 1);
+    .substring(0, 1)
+    .trim();
   vocalApellido = vocalApellido === '' ? 'X' : vocalApellido;
 
   let primeraLetraPaterno = apellidoPaterno.substring(0, 1);
@@ -299,10 +299,10 @@ function zeropad(ancho, num) {
  */
 function primerConsonante(str) {
   str = str
-    .trim()
     .substring(1)
     .replace(/[AEIOU]/gi, '')
-    .substring(0, 1);
+    .substring(0, 1)
+    .trim();
   return str === '' || str === 'Ñ' ? 'X' : str;
 }
 


### PR DESCRIPTION
Cuando de trataba de generar una CURP con un nombre donde su primer apellido en la segunda posición tenia un espacio lo generaba erróneamente, por ejemplo la CURP de **ROSA GUADALUPE O RELLING ALVARADO** debería ser `OXAR970122MVZXLS09` sin embargo se genera como `O AR970122MVZ LS09`.

Se envía propuesta de solución, Saludos. 