### PR TITLE
Fix regex en método validar para incluir género no binario

### DIFF
--- a/lib/__tests__/curp.test.js
+++ b/lib/__tests__/curp.test.js
@@ -401,6 +401,7 @@ describe('curp', () => {
   it('Deberia obtener true al validar un curp correcto', () => {
     expect(curp.validar('PXNE660720HMCXTN06')).toBe(true);
     expect(curp.validar('LOOA531113HTCPBN07')).toBe(true);
+    expect(curp.validar('PEMJ920906XNLRRS04')).toBe(true);
   });
 
   it('Debería capitalizar correctamente el nombre de los estados', () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -498,7 +498,7 @@ function validaDatos(persona) {
  */
 function validar(curpToValidate) {
   const regex =
-    /^([A-Z][AEIOUX][A-Z]{2}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])[HM](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d])(\d)$/;
+    /^([A-Z][AEIOUX][A-Z]{2}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])[HMX](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d])(\d)$/;
   const validado = curpToValidate.match(regex);
   return (
     validado &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curp",
-  "version": "1.2.3",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curp",
-      "version": "1.2.3",
+      "version": "1.3.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "coveralls": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Genera y valida el CURP (Clave Única de Registro de Población) mexicano.",
   "homepage": "",
   "author": {


### PR DESCRIPTION
Se incluyó la X en la expresión regular para permitir validar CURPs con género no binario.