### PR TITLE
Fix error TS7016 y TS2307 relacionado con types en angular

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,89 @@
+declare namespace curp {
+  interface Persona {
+    nombre?: string;
+    apellidoPaterno?: string;
+    apellidoMaterno?: string;
+    genero?: string;
+    estado?: string;
+    fechaNacimiento?: string;
+  }
+
+  interface CatalogoItem {
+    label: string;
+    value: string;
+  }
+
+  interface GeneroCatalogo {
+    readonly [key: string]: string;
+  }
+
+  interface EstadoCatalogo {
+    readonly [key: string]: string;
+  }
+}
+
+/**
+ * CURP (Clave Única de Registro de Población) es una función que proporciona
+ * métodos para validar, generar y obtener información relacionada con el CURP
+ * en México. Incluye funciones para validar el formato del CURP, generar un
+ * CURP a partir de los datos de una persona, y obtener catálogos de estados y
+ * géneros. Además, proporciona catálogos predefinidos para géneros y estados
+ * que se utilizan en la generación y validación del CURP.
+ */
+declare const curp: {
+  /**
+ * Valida que el curp cumpla con el formato y el digito verificador.
+ * @param {string} curpToValidate
+ * @returns {boolean} true de ser valido, false de ser invalido.
+ */
+  validar(curpToValidate: string): boolean;
+
+  /**
+   * Genera un objeto de tipo `Persona` como punto de partida para generar el CURP.
+   * @returns {curp.Persona} Un objeto de tipo `Persona` con campos vacíos.
+   */
+  getPersona(): curp.Persona;
+
+  /**
+   * Genera el CURP a partir de los datos de una persona.
+   * @param {curp.Persona} persona - El objeto de tipo `Persona` con los datos necesarios.
+   * @returns {string} El CURP generado.
+   */
+  generar(persona: curp.Persona): string;
+
+  /**
+ * Obtiene una lista de los estados con sus nombres capitalizados y los valores
+ * correspondientes. Utiliza la función `capitalizeWords` para asegurar que los
+ * nombres de los estados estén en formato adecuado y los ordena alfabéticamente.
+ *
+ * @returns {Array<curp.CatalogoItem>} Una lista de objetos con las propiedades `label` y `value` para cada estado,
+ *                         ordenada alfabéticamente por el label.
+ */
+  getEstados(): Array<curp.CatalogoItem>;
+
+  /**
+ * Obtiene una lista de los géneros con sus etiquetas y valores
+ * correspondientes. Los ordena alfabéticamente por etiqueta.
+ *
+ * @returns {Array<curp.CatalogoItem>} Una lista de objetos con las propiedades `label` y `value` para cada género,
+ *                         ordenada alfabéticamente por el label.
+ */
+  getGeneros(): Array<curp.CatalogoItem>;
+
+  /**
+   * Catálogo de géneros disponibles para la generación del CURP. Cada clave representa un género y su valor es el código correspondiente.
+   * Por ejemplo, "H" para Hombre, "M" para Mujer, y "X" para No Binario.
+   * Este catálogo se utiliza para validar y generar el CURP correctamente según el género seleccionado.
+   */
+  GENERO: curp.GeneroCatalogo;
+
+  /**
+   * Catálogo de estados disponibles para la generación del CURP. Cada clave representa un estado y su valor es el código correspondiente.
+   * Por ejemplo, "AS" para Aguascalientes, "BC" para Baja California, etc.
+   * Este catálogo se utiliza para validar y generar el CURP correctamente según el estado seleccionado.
+   */
+  ESTADO: curp.EstadoCatalogo;
+};
+
+export = curp;
+export as namespace curp;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curp",
-  "version": "1.2.3",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curp",
-      "version": "1.2.3",
+      "version": "1.3.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "coveralls": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,15 @@
     "lib"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "typings": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
+    }
+  },
   "keywords": [
     "curp",
     "México",


### PR DESCRIPTION
Al utilizar esta herramienta en Angular mostraba errores de TypeScript especificamente TS7016 y TS2307, para solucionar esto se creó el archivo `index.d.ts` con los types y su respectiva documentación de acuerdo con el index.js, adicionalmente para que estos cambios fueran bien recibidos en Angular se modificó el archivo `package.json`  con las declaraciones de types correspondientes.